### PR TITLE
Add GitHub Pages instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,20 @@
 # GlyphMatrixPaint
+
 New Nothing's Phone 3 Matrix Paint
+
+## GitHub Pages
+
+To host this project on GitHub Pages:
+
+1. Push the repository to GitHub.
+2. Go to **Settings** > **Pages**.
+3. Under *Branch*, choose `main` and set the folder to `/`.
+4. Save the settings.
+
+Once enabled, the site will be served from:
+
+```
+https://<USERNAME>.github.io/GlyphMatrixPaint/
+```
+
+Replace `<USERNAME>` with your GitHub username. It may take a few minutes for the page to become available.


### PR DESCRIPTION
## Summary
- add instructions for publishing the repository with GitHub Pages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68699e7c13048324bec5bfecddcac1cd